### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO let-go
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: let-go
+
+let-go-vm:
+  defines: runnable
+  metadata:
+    name: let-go-vm
+    description: Bytecode compiler and VM for the let-go language.
+    icon: https://emojiapi.dev/api/v1/crystal_ball.svg
+  containers:
+    let-go-vm:
+      image: env-5319.registry.local/let-go-vm:main-5kso90
+      build: .
+      dockerfile: Dockerfile
+  services: {}
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - let-go/let-go-vm
+  metadata:
+    name: let-go
+    description: >-
+      A bytecode compiler and VM for a Clojure-like language closely resembling
+      Clojure, designed for quality entertainment and enabling Clojure at Go
+      jobs.
+    icon: https://emojiapi.dev/api/v1/crystal_ball.svg


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Containerization of let-go VM

I've successfully containerized the let-go VM, which is a bytecode compiler and VM for a language resembling Clojure, written in Go. The application is now ready to be built and run from a Docker container using Alpine Linux as the base image. Here are the key points of the containerization process:

- The Dockerfile is set up in two stages to compile the Go code and then copy the binary to a fresh Alpine container.
- The binary named 'let-go' is placed in '/bin/let-go' and is set as the ENTRYPOINT.
- The application starts in development mode and is awaiting interaction, with no error messages in the output.
- No special configuration files or environment variables are required for the service to run, indicating it's designed to run as a standalone executable.

## Monk.io Configuration

I've added the necessary Monk.io configuration files to manage the deployment of the let-go VM service:

- `monk.yaml`: Contains the Monk configuration for the service.
- `MANIFEST`: Lists all files containing Monk configurations.

## Service Configuration and Deployment

During the configuration process, I've determined the following:

- The service listens on port 7070, which is hardcoded in the 'examples/server.lg' and 'pkg/rt/http.go' files.
- No environment variables or connections to other services are identified in the codebase.
- The service is a standalone application and does not expose any ports or require any variables to be set for deployment.

## Next Steps

The PR is complete and ready to be merged. Upon merging, the application will be re-deployed on each subsequent push. There are no further configuration steps required at this point. The let-go VM service is set to run in isolation as a standalone executable without the need for external services during startup.